### PR TITLE
[fix] touchscreen required false

### DIFF
--- a/shrine/app/src/main/AndroidManifest.xml
+++ b/shrine/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Some Chromebooks don't support touch. Although not essential, it's a good idea to explicitly include this declaration. -->
+    <uses-feature android:name="android.hardware.touchscreen"
+                  android:required="false" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## 概要

アプリのマニフェスト ファイルのアップデート
Chromebook 向け Android アプリの最適化を開始するには、マニフェスト ファイル（AndroidManifest.xml）をアップデートし、Chromebook とその他の Android 端末の主要な違い（ハードウェアおよびソフトウェアの）を明確にします。

Chrome OS バージョン M53 以降では、android.hardware.touchscreen 機能を明示的に要求しないすべての Android アプリが、android.hardware.faketouch 機能をサポートする Chrome OS 端末でも機能するようになりました。ただし、すべての Chromebook でアプリを可能な限り最適な方法で動作させるには、次の例で示されているように、マニフェスト ファイルで android.hardware.touchscreen 機能が要求されないように設定を調整します。また、マウスとキーボードのインタラクションを確認する必要があります。

```
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
          ... >
    <!-- Some Chromebooks don't support touch. Although not essential,
         it's a good idea to explicitly include this declaration. -->
    <uses-feature android:name="android.hardware.touchscreen"
                  required="false" />
</manifest>
```

参考リンク：https://developer.android.com/topic/arc/#setup